### PR TITLE
Improving aliase protection

### DIFF
--- a/roles/sympa/tasks/sympa_mail.yml
+++ b/roles/sympa/tasks/sympa_mail.yml
@@ -31,16 +31,10 @@
 - name: Compile virtual alias maps
   shell: postmap /etc/postfix/virtual
 
-- name: Check if /etc/aliases file exists
-  stat:
-    path: /etc/aliases
-  register: aliases_check
-
 - name: Creating bounce alias
   template:
     src: postfix/aliases.j2
-    dest: /etc/aliases
-  when: aliases_check.stat.exists == False
+    dest: /etc/mail/sympa_global_aliases
 
 - name: Compile bounce alias
-  shell: postalias /etc/aliases
+  shell: postalias /etc/mail/sympa_global_aliases

--- a/roles/sympa/templates/postfix/main.cf.j2
+++ b/roles/sympa/templates/postfix/main.cf.j2
@@ -30,7 +30,7 @@ smtp_tls_session_cache_database = btree:${data_directory}/smtp_scache
 smtpd_relay_restrictions = permit_mynetworks permit_sasl_authenticated defer_unauth_destination
 myhostname = {{ sympa_mail_hostname }}
 alias_maps = hash:/etc/aliases hash:/etc/mail/sympa_aliases
-alias_database = hash:/etc/aliases hash:/etc/mail/sympa_aliases
+alias_database = hash:/etc/aliases hash:/etc/mail/sympa_aliases hash:/etc/mail/sympa_global_aliases
 mydestination = $myhostname, local-sympa, localhost.localdomain, localhost 
 {% if sympa_force_smtp_route %}
 relayhost = {{ sympa_outgoing_server }}

--- a/roles/sympa/templates/postfix/main.cf.j2
+++ b/roles/sympa/templates/postfix/main.cf.j2
@@ -29,7 +29,7 @@ smtp_tls_session_cache_database = btree:${data_directory}/smtp_scache
 
 smtpd_relay_restrictions = permit_mynetworks permit_sasl_authenticated defer_unauth_destination
 myhostname = {{ sympa_mail_hostname }}
-alias_maps = hash:/etc/aliases hash:/etc/mail/sympa_aliases
+alias_maps = hash:/etc/aliases hash:/etc/mail/sympa_aliases hash:/etc/mail/sympa_global_aliases
 alias_database = hash:/etc/aliases hash:/etc/mail/sympa_aliases hash:/etc/mail/sympa_global_aliases
 mydestination = $myhostname, local-sympa, localhost.localdomain, localhost 
 {% if sympa_force_smtp_route %}


### PR DESCRIPTION
I added a sympa_global_alises file that will be always overwritten. That way, we can handle Sympa global aliases in Ansible while retaingin usage and possible cutomization of /etc/aliases.